### PR TITLE
be ready for null strings

### DIFF
--- a/lib/capitalize.js
+++ b/lib/capitalize.js
@@ -15,6 +15,9 @@
 angular.module('customFilters',[])
   .filter('capitalize', function () {
     return function (input, format) {
+      if (!input) {
+        return input;
+      }
       format = format || 'all';
       if (typeof input !== 'undefined') {
         if (format === 'first') {


### PR DESCRIPTION
sometimes the filter receives nulls (especially in ng-repeats..) no need to crash..
