### PR TITLE
diffrentiate the separator in the source from the destination

### DIFF
--- a/capitalize.js
+++ b/capitalize.js
@@ -36,7 +36,7 @@ angular.module('angular-capitalize-filter',[])
             result.push(word.charAt(0).toUpperCase() + word.slice(1).toLowerCase());
           }
         });
-        return result.join(separator);
+        return result.join(' ');
       }
     };
   });


### PR DESCRIPTION
put ' ' always at the output string no matter what the original separator is.
